### PR TITLE
fix: 修复角色Role控制层定义

### DIFF
--- a/internal/logic/sys_role/sys_role.go
+++ b/internal/logic/sys_role/sys_role.go
@@ -27,7 +27,6 @@ func init() {
 	sys_service.RegisterSysRole(New())
 }
 
-// New Auth 验证码管理服务
 func New() *sSysRole {
 	return &sSysRole{}
 }

--- a/sys_controller/sys_role.go
+++ b/sys_controller/sys_role.go
@@ -98,13 +98,13 @@ func (c *cSysRole) GetUserRoleList(ctx context.Context, req *sys_api.GetUserRole
 }
 
 // SetRolePermissions 设置角色权限
-func (c *cSysUser) SetRolePermissions(ctx context.Context, req *sys_api.SetRolePermissionsReq) (api_v1.BoolRes, error) {
+func (c *cSysRole) SetRolePermissions(ctx context.Context, req *sys_api.SetRolePermissionsReq) (api_v1.BoolRes, error) {
 	result, err := sys_service.SysRole().SetRolePermissions(ctx, req.Id, req.PermissionIds)
 	return result == true, err
 }
 
 // GetRolePermissionIds 获取角色权限Ids
-func (c *cSysUser) GetRolePermissionIds(ctx context.Context, req *sys_api.GetRolePermissionsReq) (*api_v1.Int64ArrRes, error) {
+func (c *cSysRole) GetRolePermissionIds(ctx context.Context, req *sys_api.GetRolePermissionsReq) (*api_v1.Int64ArrRes, error) {
 	result, err := sys_service.SysRole().GetRolePermissions(ctx, req.Id)
 	return (*api_v1.Int64ArrRes)(&result), err
 }


### PR DESCRIPTION
- 控制层的定义错误，导致文档出现的偏差，误导前端接口调用错误，获取权限ids返回404