### PR TITLE
feat: jwt增加获取UnionMainID的Hook，缓存至JwtClaimsUser对象中，并在相关地方使用

### DIFF
--- a/internal/logic/sys_file/sys_file.go
+++ b/internal/logic/sys_file/sys_file.go
@@ -186,11 +186,6 @@ func (s *sFile) Upload(ctx context.Context, in sys_model.FileUploadInput, userId
 		}
 	})
 
-	// 将图片信息保存到数据库
-	file, _ := s.SaveFile(ctx, absPath, userId, data)
-
-	data.Id = file.Id
-
 	return &data, nil
 }
 
@@ -296,7 +291,7 @@ func (s *sFile) UploadIDCard(ctx context.Context, in sys_model.OCRIDCardFileUplo
 		return &ret, err
 	}
 
-	ret.Id = result.Id
+	//	ret.Id = result.Id
 	ret.OCRIDCardA = OCRInfo.OCRIDCardA
 	ret.OCRIDCardB = OCRInfo.OCRIDCardB
 
@@ -330,7 +325,7 @@ func (s *sFile) UploadBankCard(ctx context.Context, in sys_model.BankCardWithOCR
 
 	// 给返回数据赋值
 	ret.BaiduSdkOCRBankCard.OCRBankCard = *bankCard
-	ret.Id = result.Id
+	// ret.Id = result.Id
 	return &ret, nil
 }
 
@@ -361,7 +356,7 @@ func (s *sFile) UploadBusinessLicense(ctx context.Context, in sys_model.OCRBusin
 	}
 
 	ret.BusinessLicenseOCR = *OCRInfo
-	ret.Id = result.Id
+	//	ret.Id = result.Id
 	return &ret, nil
 }
 

--- a/internal/logic/sys_file/sys_file.go
+++ b/internal/logic/sys_file/sys_file.go
@@ -187,7 +187,9 @@ func (s *sFile) Upload(ctx context.Context, in sys_model.FileUploadInput, userId
 	})
 
 	// 将图片信息保存到数据库
-	s.SaveFile(ctx, absPath, userId, data)
+	file, _ := s.SaveFile(ctx, absPath, userId, data)
+
+	data.Id = file.Id
 
 	return &data, nil
 }
@@ -231,7 +233,7 @@ func (s *sFile) SaveFile(ctx context.Context, storageAddr string, userId int64, 
 
 	// 记录到数据表
 	data := sys_entity.SysFile{
-		Id:        info.Id,
+		Id:        idgen.NextId(),
 		Name:      info.Name,
 		Src:       storageAddr,
 		Url:       storageAddr,

--- a/internal/logic/sys_role/sys_role.go
+++ b/internal/logic/sys_role/sys_role.go
@@ -7,7 +7,6 @@ import (
 	"github.com/SupenBysz/gf-admin-community/sys_model/sys_dao"
 	"github.com/SupenBysz/gf-admin-community/sys_model/sys_do"
 	"github.com/SupenBysz/gf-admin-community/sys_model/sys_entity"
-	"github.com/SupenBysz/gf-admin-community/sys_model/sys_enum"
 	"github.com/SupenBysz/gf-admin-community/sys_service"
 	"github.com/SupenBysz/gf-admin-community/utility/daoctl"
 	"github.com/gogf/gf/v2/container/garray"
@@ -20,10 +19,7 @@ import (
 	"github.com/yitter/idgenerator-go/idgen"
 )
 
-type hookInfo sys_model.KeyValueT[int64, sys_model.RoleHookInfo]
-
 type sSysRole struct {
-	hookArr []hookInfo
 }
 
 func init() {
@@ -31,55 +27,12 @@ func init() {
 }
 
 func New() *sSysRole {
-	return &sSysRole{
-		hookArr: make([]hookInfo, 0),
-	}
-}
-
-// InstallHook 安装Hook
-func (s *sSysRole) InstallHook(userType sys_enum.UserType, hookFunc sys_model.RoleHookFunc) int64 {
-	item := hookInfo{Key: idgen.NextId(), Value: sys_model.RoleHookInfo{Key: userType, Value: hookFunc}}
-	s.hookArr = append(s.hookArr, item)
-	return item.Key
-}
-
-// UnInstallHook 卸载Hook
-func (s *sSysRole) UnInstallHook(savedHookId int64) {
-	newFuncArr := make([]hookInfo, 0)
-	for _, item := range s.hookArr {
-		if item.Key != savedHookId {
-			newFuncArr = append(newFuncArr, item)
-			continue
-		}
-	}
-	s.hookArr = newFuncArr
-}
-
-// CleanAllHook 清除所有Hook
-func (s *sSysRole) CleanAllHook() {
-	s.hookArr = make([]hookInfo, 0)
+	return &sSysRole{}
 }
 
 // QueryRoleList 获取角色列表
 func (s *sSysRole) QueryRoleList(ctx context.Context, info sys_model.SearchParams) (*sys_model.RoleListRes, error) {
-	userId := sys_service.BizCtx().Get(ctx).ClaimsUser.Id
-
-	userInfo, err := sys_service.SysUser().GetSysUserById(ctx, userId)
-
-	var userUnionMainId int64
-
-	g.Try(ctx, func(ctx context.Context) {
-		for _, hook := range s.hookArr {
-			// 如果注入的类型一致
-			if hook.Value.Key.Code()&userInfo.Type == userInfo.Type {
-				// 直接把用户数据传入，根据返回的err判断是否跨商
-				userUnionMainId, err = hook.Value.Value(ctx, *userInfo)
-				if err != nil {
-					break
-				}
-			}
-		}
-	})
+	unionMainId := sys_service.BizCtx().Get(ctx).ClaimsUser.UnionMainId
 
 	newFields := make([]sys_model.FilterInfo, 0)
 
@@ -88,7 +41,7 @@ func (s *sSysRole) QueryRoleList(ctx context.Context, info sys_model.SearchParam
 		Field:       sys_dao.SysRole.Columns().UnionMainId,
 		Where:       "=",
 		IsOrWhere:   false,
-		Value:       userUnionMainId,
+		Value:       unionMainId,
 		IsNullValue: false,
 	})
 
@@ -257,7 +210,7 @@ func (s *sSysRole) GetRoleUsers(ctx context.Context, roleId int64) (*[]sys_model
 	if roleInfo.UnionMainId != unionMainId {
 		return nil, sys_service.SysLogs().ErrorSimple(ctx, err, "禁止跨商操作", sys_dao.SysRole.Table())
 	}
-	
+
 	if err != nil {
 		return nil, sys_service.SysLogs().ErrorSimple(ctx, err, "角色ID错误", sys_dao.SysRole.Table())
 	}

--- a/sys_model/jwt.go
+++ b/sys_model/jwt.go
@@ -1,16 +1,24 @@
 package sys_model
 
 import (
+	"context"
+	"github.com/SupenBysz/gf-admin-community/sys_model/sys_entity"
+	"github.com/SupenBysz/gf-admin-community/sys_model/sys_enum"
 	"github.com/gogf/gf/v2/os/gtime"
 	"github.com/golang-jwt/jwt/v4"
 )
 
 type JwtCustomClaims struct {
-	Id        int64       `json:"id"               description:"ID"`
-	Username  string      `json:"username"         description:"用户名"`
-	State     int         `json:"state"            description:"状态：0未激活、1正常、-1封号、-2异常、-3已注销"`
-	Type      int         `json:"type"             description:"用户类型，0匿名，1用户，2微商，4商户、8广告主、16服务商、32运营中心"`
-	CreatedAt *gtime.Time `json:"createdAt"        description:""`
-	UpdatedAt *gtime.Time `json:"updatedAt"        description:""`
+	Id          int64       `json:"id"               description:"ID"`
+	Username    string      `json:"username"         description:"用户名"`
+	State       int         `json:"state"            description:"状态：0未激活、1正常、-1封号、-2异常、-3已注销"`
+	Type        int         `json:"type"             description:"用户类型，0匿名，1用户，2微商，4商户、8广告主、16服务商、32运营中心"`
+	UnionMainId int64       `json:"union_main_id" description:"主体id"`
+	CreatedAt   *gtime.Time `json:"createdAt"        description:""`
+	UpdatedAt   *gtime.Time `json:"updatedAt"        description:""`
 	jwt.RegisteredClaims
 }
+
+type JwtHookFunc func(ctx context.Context, userInfo sys_entity.SysUser) (int64, error)
+
+type JwtHookInfo HookEventType[sys_enum.UserType, JwtHookFunc]

--- a/sys_service/sys_jwt.go
+++ b/sys_service/sys_jwt.go
@@ -8,11 +8,15 @@ package sys_service
 import (
 	"github.com/SupenBysz/gf-admin-community/sys_model"
 	"github.com/SupenBysz/gf-admin-community/sys_model/sys_entity"
+	"github.com/SupenBysz/gf-admin-community/sys_model/sys_enum"
 	"github.com/gogf/gf/v2/net/ghttp"
 )
 
 type (
 	IJwt interface {
+		InstallHook(userType sys_enum.UserType, hookFunc sys_model.JwtHookFunc) int64
+		UnInstallHook(savedHookId int64)
+		CleanAllHook()
 		GenerateToken(user *sys_entity.SysUser) (*sys_model.TokenInfo, error)
 		CreateToken(claims *sys_model.JwtCustomClaims) (string, error)
 		RefreshToken(oldToken string, claims *sys_model.JwtCustomClaims) (string, error)

--- a/sys_service/sys_role.go
+++ b/sys_service/sys_role.go
@@ -10,14 +10,10 @@ import (
 
 	"github.com/SupenBysz/gf-admin-community/sys_model"
 	"github.com/SupenBysz/gf-admin-community/sys_model/sys_entity"
-	"github.com/SupenBysz/gf-admin-community/sys_model/sys_enum"
 )
 
 type (
 	ISysRole interface {
-		InstallHook(userType sys_enum.UserType, hookFunc sys_model.RoleHookFunc) int64
-		UnInstallHook(savedHookId int64)
-		CleanAllHook()
 		QueryRoleList(ctx context.Context, info sys_model.SearchParams) (*sys_model.RoleListRes, error)
 		Create(ctx context.Context, info sys_model.SysRole) (*sys_entity.SysRole, error)
 		Update(ctx context.Context, info sys_model.SysRole) (*sys_entity.SysRole, error)


### PR DESCRIPTION
feat: jwt增加hook并获取UnionMainId
- JwtCustomClaims 增加一个 UnionMainId
- 在jwt增加hook并获取UnionMainId，然后缓存到bizctx的JwtCustomClaims 对象中。
- 然后在需要的地方拿到当前用户的UnionMainId

feat: 获取角色和角色成员禁止跨商获取
- 获取角色的时候只显示自己商内部的角色
- 获取角色成员的时候会进行UnionMainId判断，防止跨商操作

feat: 获取UnionMainId相关的hook去掉，统一采用JwtCustomClaims的unionMainId字段
- 因为jwt有定义hook并获取UnionMainId，并缓存到JwtClaimsUser对象中了
- 所以我们直接用BizCtx的ClaimsUser.UnionMainId即可