### PR TITLE
pref: 优化包引用问题

### DIFF
--- a/api_v1/sys_api/sys_file.go
+++ b/api_v1/sys_api/sys_file.go
@@ -2,7 +2,6 @@ package sys_api
 
 import (
 	"github.com/SupenBysz/gf-admin-community/sys_model"
-	"github.com/SupenBysz/gf-admin-community/sys_model/sys_entity"
 	"github.com/gogf/gf/v2/frame/g"
 )
 
@@ -38,4 +37,4 @@ type GetFileByIdReq struct {
 	Id     int64 `json:"id" v:"required#资源ID错误" dc:"文件资源ID"`
 }
 
-type UploadFileRes sys_entity.SysFile
+type UploadFileRes sys_model.UploadFile

--- a/api_v1/sys_api/sys_organization.go
+++ b/api_v1/sys_api/sys_organization.go
@@ -2,7 +2,6 @@ package sys_api
 
 import (
 	"github.com/SupenBysz/gf-admin-community/sys_model"
-	"github.com/SupenBysz/gf-admin-community/sys_model/sys_entity"
 	"github.com/gogf/gf/v2/frame/g"
 )
 
@@ -42,7 +41,7 @@ type DeleteOrganizationInfoReq struct {
 	Id     int64 `json:"id" v:"required#缺少ID参数" dc:"组织架构ID"`
 }
 
-type OrganizationInfoRes sys_entity.SysOrganization
+type OrganizationInfoRes sys_model.OrganizationInfo
 
 type OrganizationInfoTreeRes sys_model.SysOrganizationTree
 type OrganizationInfoTreeListRes []sys_model.SysOrganizationTree

--- a/api_v1/sys_api/sys_role.go
+++ b/api_v1/sys_api/sys_role.go
@@ -3,8 +3,6 @@ package sys_api
 import (
 	"github.com/SupenBysz/gf-admin-community/sys_model"
 	"github.com/gogf/gf/v2/frame/g"
-
-	"github.com/SupenBysz/gf-admin-community/sys_model/sys_entity"
 )
 
 type QueryRoleListReq struct {
@@ -60,5 +58,5 @@ type GetRolePermissionsIdsReq struct {
 	Id     string `json:"id" v:"required#角色ID校验失败" dc:"角色ID"`
 }
 
-type RoleInfoRes sys_entity.SysRole
+type RoleInfoRes sys_model.RoleInfo
 type UserListRes sys_model.CollectRes[sys_model.SysUser]

--- a/api_v1/sys_api/sys_user.go
+++ b/api_v1/sys_api/sys_user.go
@@ -2,7 +2,6 @@ package sys_api
 
 import (
 	"github.com/SupenBysz/gf-admin-community/sys_model"
-	"github.com/SupenBysz/gf-admin-community/sys_model/sys_entity"
 	"github.com/gogf/gf/v2/frame/g"
 )
 
@@ -27,8 +26,8 @@ type GetUserPermissionIdsReq struct {
 	Id     string `json:"id" v:"required#用户ID校验失败" dc:"用户ID"`
 }
 
-type UserInfoRes sys_entity.SysUser
-type UserInfoListRes sys_model.CollectRes[sys_entity.SysUser]
+type UserInfoRes sys_model.UserInfo
+type UserInfoListRes sys_model.UserInfoList
 
 type ResetUserPasswordReq struct {
 	g.Meta          `path:"/resetUserPasswordReq" method:"post" summary:"重置用户密码" tags:"用户"`

--- a/internal/logic/sys_permission/sys_permission.go
+++ b/internal/logic/sys_permission/sys_permission.go
@@ -417,7 +417,7 @@ func (s *sSysPermission) CheckPermission(ctx context.Context, tree ...*permissio
 }
 
 // CheckPermissionOr 校验权限，任意一个满足则有权限
-func (s *sSysPermission) CheckPermissionOr(ctx context.Context, tree ...*permission.SysPermissionTree) (has bool, err error) { // 权限id  域 资源  方法
+func (s *sSysPermission) CheckPermissionOr(ctx context.Context, tree ...*permission.SysPermissionTree) (has bool, err error) { // 用户id  域 资源  方法
 	for _, permissionTree := range tree {
 		permissionResourceKey := gconv.String(permissionTree.Id)
 		if permissionTree.MatchMode > 0 {

--- a/sys_model/sys_file.go
+++ b/sys_model/sys_file.go
@@ -19,6 +19,8 @@ type FileInfo struct {
 	ExpiresAt *gtime.Time
 }
 
+type UploadFile sys_entity.SysFile
+
 // OCRIDCardFileUploadInput 上传身份证请求参数
 type OCRIDCardFileUploadInput struct {
 	FileUploadInput

--- a/sys_model/sys_organization.go
+++ b/sys_model/sys_organization.go
@@ -16,3 +16,5 @@ type SysOrganizationTree struct {
 }
 
 type OrganizationInfoListRes CollectRes[sys_entity.SysOrganization]
+
+type OrganizationInfo sys_entity.SysOrganization

--- a/sys_model/sys_role.go
+++ b/sys_model/sys_role.go
@@ -13,3 +13,5 @@ type SysRole struct {
 }
 
 type RoleListRes CollectRes[sys_entity.SysRole]
+
+type RoleInfo sys_entity.SysRole

--- a/sys_model/sys_user.go
+++ b/sys_model/sys_user.go
@@ -36,7 +36,8 @@ type UpdateUserPassword struct {
 	ConfirmPassword string `json:"confirmPassword" v:"required#请确认密码" dc:"确认密码"`
 }
 
-type SysUserList []sys_entity.SysUser
+type UserInfo sys_entity.SysUser
+type UserInfoList CollectRes[sys_entity.SysUser]
 type SysUserListRes CollectRes[SysUser]
 
 type UserHookFunc HookFunc[sys_enum.UserEvent, sys_entity.SysUser]


### PR DESCRIPTION
包引用问题：
-  login逻辑里面不要用api的包

- login逻辑里是常规类型不要包装

- 容易跨项目引起交叉引用，到时编译不过都查不到哪里问题，交叉引用问题导致的编译不过排查很费劲的。

- login参数用 model，entity 包

- entity不能满足的在model包进行封装或取别名

login层
- logic服务层一般返回类型包为entity或model
- 不要在 服务层使用接口api包中定义的类型。例如 v1 包/api_v1

api层：
- do，只在service使用，entity 在model起别名后给api用。
- 不要直接在api包写entity

controller层：
- controler也不要出现entity，
- controller 可以用service，api，model这3个包下的成员或方法