### PR TITLE
fix: 修复返回的文件请求URL和实际接口不一致BUG

### DIFF
--- a/internal/logic/sys_file/sys_file.go
+++ b/internal/logic/sys_file/sys_file.go
@@ -391,7 +391,7 @@ func (s *sFile) GetUrlById(id int64) string {
 	apiPrefix := sys_consts.Global.ApiPreFix
 
 	// 拼接请求url
-	return apiPrefix + "/common/sys_file/getFileById?id=" + gconv.String(id)
+	return apiPrefix + "/common/file/getFileById?id=" + gconv.String(id)
 }
 
 // GetFileById 根据id获取并返回文件信息


### PR DESCRIPTION
- 实际可访问URL：/kmk/admin/common/file/getFileById?id=xxx
- 修改前：/kmk/admin/common/sys_file/getFileById?id=xxx