### PR TITLE
fix: 修复设置资源权限逻辑

### DIFF
--- a/internal/logic/sys_permission/sys_permission.go
+++ b/internal/logic/sys_permission/sys_permission.go
@@ -227,7 +227,7 @@ func (s *sSysPermission) SetPermissionsByResource(ctx context.Context, resourceI
 				PageSize: 10000,
 			},
 		})
-		if data != nil {
+		if data == nil {
 			return false, sys_service.SysLogs().ErrorSimple(ctx, err, "权限ID校验失败失败", sys_dao.SysRole.Table())
 		}
 		items = data.List
@@ -249,7 +249,8 @@ func (s *sSysPermission) SetPermissionsByResource(ctx context.Context, resourceI
 				permissionResourceKey = item.Identifier
 			}
 			ret, err := sys_service.Casbin().Enforcer().AddPermissionForUser(resourceIdentifier, sys_consts.CasbinDomain, permissionResourceKey, "allow")
-			if err != nil || ret == false {
+			// if err != nil && ret == false {  //一个失败其他继续设置
+			if err != nil || ret == false { // 一个失败，退出
 				return err
 			}
 		}


### PR DESCRIPTION
- 查询权限列表后应该判断：如果权限列表为空，权限ID检验失败
- 有注释的地方我也不太确定就没修改