### PR TITLE
pref: 用户模块接入替换with的funs.AttrMake和funs.AttrBuilder方案

### DIFF
--- a/internal/logic/sys_user/sys_user.go
+++ b/internal/logic/sys_user/sys_user.go
@@ -684,11 +684,11 @@ func (s *sSysUser) UpdateUserExDetail(ctx context.Context, user *sys_model.SysUs
 }
 
 // GetUserDetail 查看用户详情，含完整手机号
-func (s *sSysUser) GetUserDetail(ctx context.Context, userId int64) (*sys_entity.SysUser, error) {
+func (s *sSysUser) GetUserDetail(ctx context.Context, userId int64) (*sys_model.SysUser, error) {
 	s.initInnerCacheItems(ctx)
 
 	// Ctx()里面包含对所有Cache操作的赋值，查询不需要写Cache
-	user := sys_entity.SysUser{}
+	user := sys_model.SysUser{}
 	err := sys_dao.SysUser.Ctx(ctx).Where(sys_do.SysUser{
 		Id: userId,
 	}).Scan(&user)
@@ -698,7 +698,8 @@ func (s *sSysUser) GetUserDetail(ctx context.Context, userId int64) (*sys_entity
 	}
 
 	user.Password = masker.MaskString(user.Password, masker.Password)
-	return &user, nil
+
+	return s.makeMore(ctx, &user), nil
 }
 
 // SetUserMobile 设置用户手机号

--- a/internal/logic/sys_user/sys_user.go
+++ b/internal/logic/sys_user/sys_user.go
@@ -744,3 +744,20 @@ func (s *sSysUser) masker(user *sys_model.SysUser) *sys_model.SysUser {
 	user.Mobile = masker.MaskString(user.Mobile, masker.MaskPhone)
 	return user
 }
+
+// makeMore 处理订阅请求，获取订阅数据回调返回
+func (s *sSysUser) makeMore(ctx context.Context, data *sys_model.SysUser) *sys_model.SysUser {
+	funs.AttrMake[sys_model.SysUser](ctx,
+		sys_dao.SysUser.Columns().Id,
+		func() *sys_entity.SysUserDetail {
+			result, _ := daoctl.GetByIdWithError[sys_entity.SysUserDetail](sys_dao.SysUserDetail.Ctx(ctx), data.Id)
+			if result == nil {
+				return nil
+			}
+			res := kconv.Struct[sys_entity.SysUserDetail](ctx, *result)
+			data.Detail = res
+			return &data.Detail
+		},
+	)
+	return data
+}

--- a/sys_controller/sys_user.go
+++ b/sys_controller/sys_user.go
@@ -5,6 +5,8 @@ import (
 	"github.com/SupenBysz/gf-admin-community/api_v1"
 	"github.com/SupenBysz/gf-admin-community/api_v1/sys_api"
 	"github.com/SupenBysz/gf-admin-community/sys_model"
+	"github.com/SupenBysz/gf-admin-community/sys_model/sys_dao"
+	"github.com/SupenBysz/gf-admin-community/sys_model/sys_entity"
 	"github.com/SupenBysz/gf-admin-community/sys_model/sys_enum"
 	"github.com/SupenBysz/gf-admin-community/sys_service"
 	"github.com/SupenBysz/gf-admin-community/utility/funs"
@@ -22,7 +24,7 @@ func (c *cSysUser) QueryUserList(ctx context.Context, req *sys_api.QueryUserList
 		func() (*sys_model.SysUserListRes, error) {
 			sessionUser := sys_service.SysSession().Get(ctx).JwtClaimsUser
 			return sys_service.SysUser().QueryUserList(
-				ctx,
+				c.makeMore(ctx),
 				&req.SearchParams,
 				sessionUser.UnionMainId,
 				false,
@@ -64,10 +66,7 @@ func (c *cSysUser) GetUserPermissionIds(ctx context.Context, req *sys_api.GetUse
 func (c *cSysUser) GetUserDetail(ctx context.Context, req *sys_api.GetUserDetailReq) (*sys_api.UserInfoRes, error) {
 	return funs.CheckPermission(ctx,
 		func() (*sys_api.UserInfoRes, error) {
-			ret, err := sys_service.SysUser().GetUserDetail(
-				ctx,
-				req.Id,
-			)
+			ret, err := sys_service.SysUser().GetUserDetail(c.makeMore(ctx), req.Id)
 			return kconv.Struct(ret, &sys_api.UserInfoRes{}), err
 		},
 		sys_enum.User.PermissionType.ViewMoreDetail,

--- a/sys_controller/sys_user.go
+++ b/sys_controller/sys_user.go
@@ -119,3 +119,8 @@ func (c *cSysUser) SetUserState(ctx context.Context, req *sys_api.SetUserStateRe
 		sys_enum.User.PermissionType.SetState,
 	)
 }
+
+// makeMore 是否订阅附加数据
+func (c *cSysUser) makeMore(ctx context.Context) context.Context {
+	return funs.AttrBuilder[sys_model.SysUser, *sys_entity.SysUserDetail](ctx, sys_dao.SysUser.Columns().Id)
+}

--- a/sys_service/sys_user.go
+++ b/sys_service/sys_user.go
@@ -9,7 +9,6 @@ import (
 	"context"
 
 	"github.com/SupenBysz/gf-admin-community/sys_model"
-	"github.com/SupenBysz/gf-admin-community/sys_model/sys_entity"
 	"github.com/SupenBysz/gf-admin-community/sys_model/sys_enum"
 	"github.com/SupenBysz/gf-admin-community/sys_model/sys_hook"
 )
@@ -35,7 +34,7 @@ type (
 		ResetUserPassword(ctx context.Context, userId int64, password string, confirmPassword string) (bool, error)
 		SetUserRoles(ctx context.Context, userId int64, roleIds []int64, makeUserUnionMainId int64) (bool, error)
 		UpdateUserExDetail(ctx context.Context, user *sys_model.SysUser) (*sys_model.SysUser, error)
-		GetUserDetail(ctx context.Context, userId int64) (*sys_entity.SysUser, error)
+		GetUserDetail(ctx context.Context, userId int64) (*sys_model.SysUser, error)
 		SetUserMobile(ctx context.Context, newMobile int64, captcha string, password string, userId int64) (bool, error)
 	}
 )


### PR DESCRIPTION
- 两者配套使用
- 大多情况下都是 logic里用 AttrMake，controller里用AttrBuild

- 通常需要附加数据的在controller层订阅，也就是AttrBuilder
- 通常login层请求订阅数据 ，也就是调用funs.AttrMake

- 注意：两者的目标对象，键名，回调函数返回类型一致才能完成回调