### PR TITLE
fix: 修复文件保存逻辑Bug- 无论是Src还是URL都是存储的info的临时路径

### DIFF
--- a/internal/logic/sys_file/sys_file.go
+++ b/internal/logic/sys_file/sys_file.go
@@ -230,8 +230,10 @@ func (s *sFile) SaveFile(ctx context.Context, storageAddr string, info *sys_mode
 			}
 		}
 	})
-
+	// 记录到数据表
 	data := kconv.Struct(info.SysFile, &sys_do.SysFile{})
+	data.Src = storageAddr
+	data.Url = storageAddr
 
 	count, err := sys_dao.SysFile.Ctx(ctx).Where(sys_do.SysFile{Id: data.Id}).Count()
 	if count == 0 {


### PR DESCRIPTION
注意：在一次优化中迭代掉了：
- 这是原来的赋值逻辑：
 `
 	// 记录到数据表
	data := sys_entity.SysFile{
	
		Id:        idgen.NextId(),
		Name:      info.Name, 
		Src:       storageAddr,
		Url:       storageAddr,
		Ext:       gfile.Ext(storageAddr),
		Size:      info.Size,
		UserId:    userId,
		CreatedAt: gtime.Now(),
	}
`

- 这是最新的赋值逻辑： (少了storageAddr的赋值操作)
 `
	data := kconv.Struct(info.SysFile, &sys_do.SysFile{})
`